### PR TITLE
 If you use --strict, this will cause Cucumber to exit with 1.

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/cucumber/RunCucumber.kt
+++ b/src/main/kotlin/no/nav/dagpenger/cucumber/RunCucumber.kt
@@ -5,6 +5,7 @@ import io.cucumber.core.cli.Main
 val args = arrayOf(
     "-g", "no.nav.dagpenger",
     "-p", "pretty",
+    "--strict",
     "classpath:features",
     "--tags", "not @ignored ")
 


### PR DESCRIPTION
(https://cucumber.io/docs/cucumber/api/)